### PR TITLE
feat: add max lines limit and exclude lock files

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cmt"
 version = "0.3.33"
 edition = "2021"
-description = "A CLI tool that generates commit messages using OpenAI or Anthropic Claude"
+description = "CLI tool that generates commit messages using AI"
 authors = ["Clifton King <cliftonk@gmail.com>"]
 license = "MIT"
 repository = "https://github.com/cliftonk/cmt"

--- a/README.md
+++ b/README.md
@@ -87,17 +87,30 @@ git commit -F <(cmt --message-only)
 Usage: cmt [OPTIONS]
 
 Options:
-  -m, --message-only               Only output the generated commit message, without formatting
-      --no-diff-stats             Hide the diff statistics for staged changes
-      --show-raw-diff             Show the raw git diff that will be sent to the AI model
-      --context-lines <LINES>      Number of context lines to show in the git diff (default: 12)
-      --model <MODEL>              Use a specific AI model (defaults to claude-3-5-sonnet-latest or gpt-4o depending on provider)
-      --openai                     Use OpenAI instead of Claude (which is default)
-      --anthropic                  Use Anthropic instead of OpenAI (which is default)
-  -t, --temperature <TEMPERATURE>  Adjust the creativity of the generated message (0.0 to 2.0)
-      --hint <HINT>                Add a hint to guide the AI in generating the commit message
-  -h, --help                       Print help
-  -V, --version                    Print version
+  -m, --message-only
+          Only output the generated commit message, without formatting
+      --no-diff-stats
+          Hide the diff statistics for staged changes
+      --show-raw-diff
+          Show the raw git diff that will be sent to the AI model
+      --context-lines <CONTEXT_LINES>
+          Number of context lines to show in the git diff [default: 12]
+      --model <MODEL>
+          Use a specific AI model (defaults to claude-3-5-sonnet-latest or gpt-4o depending on provider)
+      --openai
+          Use OpenAI
+      --anthropic
+          Use Anthropic (default)
+  -t, --temperature <TEMPERATURE>
+          Adjust the creativity of the generated message (0.0 to 2.0)
+      --hint <HINT>
+          Add a hint to guide the AI in generating the commit message
+      --max-lines-per-file <MAX_LINES_PER_FILE>
+          Number of maximum lines to show per file in the git diff [default: 500]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 ```
 
 ### Examples
@@ -181,3 +194,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.
+

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,14 +25,15 @@ fn main() {
         }
     };
 
-    let staged_changes = match cmt::get_staged_changes(&repo, args.context_lines) {
-        Ok(changes) => changes,
-        Err(e) => {
-            eprintln!("{}", "Error:".red().bold());
-            eprintln!("{}", e);
-            process::exit(1);
-        }
-    };
+    let staged_changes =
+        match cmt::get_staged_changes(&repo, args.context_lines, args.max_lines_per_file) {
+            Ok(changes) => changes,
+            Err(e) => {
+                eprintln!("{}", "Error:".red().bold());
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        };
 
     let recent_commits = match cmt::get_recent_commits(&repo, 5) {
         Ok(commits) => commits,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,15 +25,19 @@ fn main() {
         }
     };
 
-    let staged_changes =
-        match cmt::get_staged_changes(&repo, args.context_lines, args.max_lines_per_file) {
-            Ok(changes) => changes,
-            Err(e) => {
-                eprintln!("{}", "Error:".red().bold());
-                eprintln!("{}", e);
-                process::exit(1);
-            }
-        };
+    let staged_changes = match cmt::get_staged_changes(
+        &repo,
+        args.context_lines,
+        args.max_lines_per_file,
+        args.max_line_width,
+    ) {
+        Ok(changes) => changes,
+        Err(e) => {
+            eprintln!("{}", "Error:".red().bold());
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
 
     let recent_commits = match cmt::get_recent_commits(&repo, 5) {
         Ok(commits) => commits,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,7 +16,7 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub show_raw_diff: bool,
 
-    /// Number of context lines to show in the git diff (default: 12)
+    /// Number of context lines to show in the git diff
     #[arg(long, default_value_t = 12)]
     pub context_lines: u32,
 
@@ -24,11 +24,11 @@ pub struct Args {
     #[arg(long)]
     pub model: Option<String>,
 
-    /// Use OpenAI instead of Claude (which is default)
+    /// Use OpenAI
     #[arg(long)]
     pub openai: bool,
 
-    /// Use Anthropic instead of OpenAI (which is default)
+    /// Use Anthropic (default)
     #[arg(long, default_value_t = true)]
     pub anthropic: bool,
 
@@ -39,6 +39,10 @@ pub struct Args {
     /// Add a hint to guide the AI in generating the commit message
     #[arg(long)]
     pub hint: Option<String>,
+
+    /// Number of maximum lines to show per file in the git diff
+    #[arg(long, default_value_t = 500)]
+    pub max_lines_per_file: usize,
 }
 
 impl Args {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,10 @@ pub struct Args {
     /// Number of maximum lines to show per file in the git diff
     #[arg(long, default_value_t = 500)]
     pub max_lines_per_file: usize,
+
+    /// Maximum line width for diffs
+    #[arg(long, default_value_t = 300)]
+    pub max_line_width: usize,
 }
 
 impl Args {

--- a/src/git.rs
+++ b/src/git.rs
@@ -23,7 +23,11 @@ pub fn get_recent_commits(repo: &Repository, count: usize) -> Result<String, Git
     Ok(commit_messages)
 }
 
-pub fn get_staged_changes(repo: &Repository, context_lines: u32) -> Result<String, GitError> {
+pub fn get_staged_changes(
+    repo: &Repository,
+    context_lines: u32,
+    max_lines_per_file: usize,
+) -> Result<String, GitError> {
     let mut opts = git2::DiffOptions::new();
     opts.context_lines(context_lines);
 
@@ -43,17 +47,34 @@ pub fn get_staged_changes(repo: &Repository, context_lines: u32) -> Result<Strin
         .map_err(|e| GitError::from_str(&format!("Failed to get repository diff: {}", e)))?;
 
     let mut diff_str = String::new();
-    diff.print(git2::DiffFormat::Patch, |_, _, line| {
-        match line.origin() {
-            '+' | '-' | ' ' => {
-                // Preserve the prefix character for additions, deletions, and context
-                diff_str.push(line.origin());
-                diff_str.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
+    let mut line_count = 0;
+    let mut truncated = false;
+
+    diff.print(git2::DiffFormat::Patch, |delta, _, line| {
+        let file_path = delta
+            .new_file()
+            .path()
+            .unwrap_or_else(|| std::path::Path::new(""));
+        if file_path.extension().map_or(false, |ext| ext == "lock") {
+            return true; // Skip .lock files
+        }
+
+        if line_count < max_lines_per_file {
+            match line.origin() {
+                '+' | '-' | ' ' => {
+                    // Preserve the prefix character for additions, deletions, and context
+                    diff_str.push(line.origin());
+                    diff_str.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
+                    line_count += 1; // Increment line count only for content lines
+                }
+                _ => {
+                    // For headers and other lines, just add the content
+                    diff_str.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
+                }
             }
-            _ => {
-                // For headers and other lines, just add the content
-                diff_str.push_str(std::str::from_utf8(line.content()).unwrap_or(""));
-            }
+        } else if !truncated {
+            truncated = true;
+            diff_str.push_str("\n[Note: Diff output truncated to max lines per file.]");
         }
         true
     })
@@ -214,7 +235,7 @@ mod tests {
     #[test]
     fn test_get_staged_changes_empty_repo() {
         let (_temp_dir, repo) = setup_test_repo();
-        let result = get_staged_changes(&repo, 0);
+        let result = get_staged_changes(&repo, 0, 100);
         assert!(result.is_err());
         assert_eq!(
             result.unwrap_err().message(),
@@ -229,7 +250,7 @@ mod tests {
         // Create and stage a new file
         create_and_stage_file(&repo, "test.txt", "Hello, World!");
 
-        let changes = get_staged_changes(&repo, 0).unwrap();
+        let changes = get_staged_changes(&repo, 0, 100).unwrap();
         assert!(changes.contains("Hello, World!"));
     }
 
@@ -244,7 +265,7 @@ mod tests {
         // Modify and stage the file
         create_and_stage_file(&repo, "test.txt", "Modified content");
 
-        let changes = get_staged_changes(&repo, 0).unwrap();
+        let changes = get_staged_changes(&repo, 0, 100).unwrap();
         assert!(changes.contains("Initial content"));
         assert!(changes.contains("Modified content"));
     }
@@ -288,5 +309,49 @@ mod tests {
         // Should succeed and include warning about unstaged changes
         let result = git_staged_changes(&repo);
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_exclude_lock_files_from_diff() {
+        let (_temp_dir, repo) = setup_test_repo();
+
+        // Create and stage a .lock file
+        create_and_stage_file(&repo, "test.lock", "This is a lock file.");
+
+        // Create and stage a regular file
+        create_and_stage_file(&repo, "test.txt", "This is a regular file.");
+
+        let changes = get_staged_changes(&repo, 0, 100).unwrap();
+
+        // Assert that the .lock file content is not in the diff
+        assert!(!changes.contains("This is a lock file."));
+
+        // Assert that the regular file content is in the diff
+        assert!(changes.contains("This is a regular file."));
+    }
+
+    #[test]
+    fn test_max_lines_per_file_limit() {
+        let (_temp_dir, repo) = setup_test_repo();
+
+        // Create and stage a file with more lines than the max_lines_per_file limit
+        let mut content = String::new();
+        for i in 0..600 {
+            content.push_str(&format!("Line {}\n", i));
+        }
+        create_and_stage_file(&repo, "test.txt", &content);
+
+        // Set max_lines_per_file to 10 for testing
+        let max_lines_per_file = 10;
+        let changes = get_staged_changes(&repo, 0, max_lines_per_file).unwrap();
+
+        // Assert that the diff output does not exceed the max_lines_per_file limit
+        // Allow extra lines for headers and metadata
+        // let allowed_extra_lines = 6; // Adjust this number based on typical header lines
+
+        // Assert that the truncation note is included
+        assert!(changes.contains("[Note: Diff output truncated to max lines per file.]"));
+        assert!(changes.contains(&format!("+Line {}", max_lines_per_file - 1)));
+        assert!(!changes.contains(&format!("+Line {}", max_lines_per_file)));
     }
 }


### PR DESCRIPTION
- Add max_lines_per_file option to limit diff output per file
- Skip lock files when generating git diffs
- Update CLI help text for improved clarity
- Add truncation notice when files exceed line limit
- Add tests for lock file exclusion and line limit features
- Update Anthropic as default provider in help text