### PR TITLE
Sensible max token temp defaults

### DIFF
--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -153,9 +153,9 @@ git add test.txt
 # Capture the full output to verify both diff stats and file name
 output=$("$CMT_BIN")
 
-# Check for "Diff Statistics:" header
-if ! echo "$output" | grep -q "Diff Statistics:"; then
-    echo "❌ Failed: Missing 'Diff Statistics:' header in output"
+# Check for "Staged:" header (new format)
+if ! echo "$output" | grep -q "Staged:"; then
+    echo "❌ Failed: Missing 'Staged:' header in output"
     echo "Output was:"
     echo "$output"
     exit 1
@@ -169,8 +169,8 @@ if ! echo "$output" | grep -q "test.txt"; then
     exit 1
 fi
 
-# Check for file change indicators
-if ! echo "$output" | grep -q "file.*changed"; then
+# Check for file change indicators (new format: "Staged: X file(s)")
+if ! echo "$output" | grep -qE "Staged:.*file"; then
     echo "❌ Failed: Missing file change statistics"
     echo "Output was:"
     echo "$output"

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -75,7 +75,7 @@ impl AiProvider for ClaudeProvider {
             .header("content-type", "application/json")
             .json(&json!({
                 "model": model,
-                "max_tokens": 1024,
+                "max_tokens": crate::ai::DEFAULT_MAX_TOKENS,
                 "temperature": temperature,
                 "system": json_system_prompt,
                 "messages": [{
@@ -136,7 +136,7 @@ impl AiProvider for ClaudeProvider {
     }
 
     fn default_temperature(&self) -> f32 {
-        crate::ai::CLAUDE_DEFAULT_TEMP
+        crate::ai::DEFAULT_TEMPERATURE
     }
 
     fn check_available(&self) -> Result<(), Box<dyn Error>> {

--- a/src/ai/claude.rs
+++ b/src/ai/claude.rs
@@ -101,9 +101,35 @@ impl AiProvider for ClaudeProvider {
                 }));
             }
 
+            // Provide clearer error messages for common HTTP errors
+            let error_msg = match status.as_u16() {
+                520..=524 => {
+                    format!(
+                        "Cloudflare/API gateway error (status {}): {}. This is usually transient - please try again.",
+                        status.as_u16(),
+                        error_text
+                    )
+                }
+                429 => {
+                    format!(
+                        "Rate limit exceeded (status {}): {}. Please wait a moment and try again.",
+                        status.as_u16(),
+                        error_text
+                    )
+                }
+                503 => {
+                    format!(
+                        "Service unavailable (status {}): {}. The API may be temporarily down - please try again.",
+                        status.as_u16(),
+                        error_text
+                    )
+                }
+                _ => format!("API error (status {}): {}", status.as_u16(), error_text),
+            };
+
             return Err(Box::new(AiError::ApiError {
                 code: status.as_u16(),
-                message: format!("API error (status {}): {}", status, error_text),
+                message: error_msg,
             }));
         }
 

--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -117,9 +117,35 @@ impl AiProvider for GeminiProvider {
                 }));
             }
 
+            // Provide clearer error messages for common HTTP errors
+            let error_msg = match status.as_u16() {
+                520..=524 => {
+                    format!(
+                        "Cloudflare/API gateway error (status {}): {}. This is usually transient - please try again.",
+                        status.as_u16(),
+                        error_text
+                    )
+                }
+                429 => {
+                    format!(
+                        "Rate limit exceeded (status {}): {}. Please wait a moment and try again.",
+                        status.as_u16(),
+                        error_text
+                    )
+                }
+                503 => {
+                    format!(
+                        "Service unavailable (status {}): {}. The API may be temporarily down - please try again.",
+                        status.as_u16(),
+                        error_text
+                    )
+                }
+                _ => format!("API error (status {}): {}", status.as_u16(), error_text),
+            };
+
             return Err(Box::new(AiError::ApiError {
                 code: status.as_u16(),
-                message: format!("API error (status {}): {}", status, error_text),
+                message: error_msg,
             }));
         }
 

--- a/src/ai/gemini.rs
+++ b/src/ai/gemini.rs
@@ -1,5 +1,7 @@
 use crate::ai::http::{handle_request_error, parse_json_response};
-use crate::ai::{parse_commit_template_json, AiError, AiProvider, GEMINI_DEFAULT_TEMP};
+use crate::ai::{
+    parse_commit_template_json, AiError, AiProvider, DEFAULT_MAX_TOKENS, DEFAULT_TEMPERATURE,
+};
 use crate::templates::CommitTemplate;
 use reqwest::blocking::Client;
 use serde_json::{json, Value};
@@ -91,7 +93,7 @@ impl AiProvider for GeminiProvider {
                 }],
                 "generationConfig": {
                     "temperature": temperature,
-                    "maxOutputTokens": 2048,
+                    "maxOutputTokens": DEFAULT_MAX_TOKENS,
                     "responseMimeType": "application/json"
                 }
             }))
@@ -151,7 +153,7 @@ impl AiProvider for GeminiProvider {
     }
 
     fn default_temperature(&self) -> f32 {
-        GEMINI_DEFAULT_TEMP
+        DEFAULT_TEMPERATURE
     }
 
     fn check_available(&self) -> Result<(), Box<dyn Error>> {

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -11,9 +11,13 @@ use std::error::Error;
 use std::fmt::Debug;
 use std::sync::Arc;
 
-pub const CLAUDE_DEFAULT_TEMP: f32 = 0.3;
-pub const OPENAI_DEFAULT_TEMP: f32 = 1.0;
-pub const GEMINI_DEFAULT_TEMP: f32 = 0.7;
+// Temperature 0.3 is optimal for structured JSON output:
+// - Low enough for reliable, consistent JSON formatting
+// - High enough for natural language variety in commit messages
+pub const DEFAULT_TEMPERATURE: f32 = 0.3;
+
+// Max output tokens - 16k is generous for commit messages
+pub const DEFAULT_MAX_TOKENS: u32 = 16384;
 
 lazy_static! {
     /// The JSON schema for CommitTemplate, generated once and reused

--- a/src/ai/mod.rs
+++ b/src/ai/mod.rs
@@ -16,8 +16,9 @@ use std::sync::Arc;
 // - High enough for natural language variety in commit messages
 pub const DEFAULT_TEMPERATURE: f32 = 0.3;
 
-// Max output tokens - 16k is generous for commit messages
-pub const DEFAULT_MAX_TOKENS: u32 = 16384;
+// Max output tokens - 4096 provides headroom for JSON structure overhead
+// while still being much smaller than the previous 16k
+pub const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 lazy_static! {
     /// The JSON schema for CommitTemplate, generated once and reused

--- a/src/ai/openai.rs
+++ b/src/ai/openai.rs
@@ -89,6 +89,7 @@ impl AiProvider for OpenAiProvider {
                     }
                 ],
                 "temperature": temperature,
+                "max_completion_tokens": crate::ai::DEFAULT_MAX_TOKENS,
                 "tools": [
                     {
                         "type": "function",
@@ -157,7 +158,7 @@ impl AiProvider for OpenAiProvider {
     }
 
     fn default_temperature(&self) -> f32 {
-        crate::ai::OPENAI_DEFAULT_TEMP
+        crate::ai::DEFAULT_TEMPERATURE
     }
 
     fn check_available(&self) -> Result<(), Box<dyn Error>> {

--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -149,8 +149,11 @@ impl DiffAnalysis {
         }
 
         // File list
-        summary.push_str("\n## Changed Files\n");
-        for file in &self.files {
+        summary.push_str("\n## Changed Files (top 20 by churn)\n");
+        let mut files = self.files.clone();
+        files.sort_by_key(|f| -(f.insertions as isize + f.deletions as isize));
+        let top_n = 20usize.min(files.len());
+        for file in files.iter().take(top_n) {
             let op_indicator = match file.operation {
                 FileOperation::Added => "+",
                 FileOperation::Deleted => "-",
@@ -174,6 +177,12 @@ impl DiffAnalysis {
                     file.category.as_str()
                 ));
             }
+        }
+        if self.files.len() > top_n {
+            summary.push_str(&format!(
+                "+{} other files not listed\n",
+                self.files.len() - top_n
+            ));
         }
 
         // Suggested type

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -17,7 +17,7 @@ pub struct Args {
     pub show_raw_diff: bool,
 
     /// Number of context lines to show in the git diff
-    #[arg(long, default_value_t = 12)]
+    #[arg(long, default_value_t = 8)]
     pub context_lines: u32,
 
     /// Use a specific AI model (defaults to gemini-3-flash-preview, claude-sonnet-4-5-20250929, or gpt-5.2 depending on provider)
@@ -37,7 +37,7 @@ pub struct Args {
     pub hint: Option<String>,
 
     /// Number of maximum lines to show per file in the git diff
-    #[arg(long, default_value_t = 500)]
+    #[arg(long, default_value_t = 300)]
     pub max_lines_per_file: usize,
 
     /// Maximum line width for diffs
@@ -113,7 +113,7 @@ mod tests {
         assert!(!args.message_only);
         assert!(!args.no_diff_stats);
         assert!(!args.show_raw_diff);
-        assert_eq!(args.context_lines, 12);
+        assert_eq!(args.context_lines, 8);
         assert!(args.model.is_none());
         assert!(args.temperature.is_none());
         assert!(args.hint.is_none());

--- a/src/git.rs
+++ b/src/git.rs
@@ -201,11 +201,10 @@ pub fn get_staged_changes(
     };
 
     // Adaptive trimming: tighten context/line caps only for large diffs
-    let large_diff =
-        stats.files_changed > 40 || (stats.insertions + stats.deletions) > 4000;
+    let large_diff = stats.files_changed > 40 || (stats.insertions + stats.deletions) > 4000;
     let effective_context_lines = if large_diff {
         // Keep enough context to preserve meaning, but trim heavy payloads
-        cmp::max(3, cmp::min(context_lines, 6))
+        context_lines.clamp(3, 6)
     } else {
         context_lines
     };
@@ -280,7 +279,6 @@ fn has_unstaged_changes(repo: &Repository) -> Result<bool, GitError> {
     let diff = repo.diff_index_to_workdir(None, None)?;
     Ok(diff.stats()?.files_changed() > 0)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 pub use crate::config::cli::Args;
-pub use crate::git::{get_recent_commits, get_staged_changes, git_staged_changes};
+pub use crate::git::{get_recent_commits, get_staged_changes, DiffStats, StagedChanges};
 
 mod ai;
 mod analysis;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **LLM defaults and errors**
> - Introduces `DEFAULT_TEMPERATURE` (0.3) and `DEFAULT_MAX_TOKENS` (4096); updates `claude`, `gemini`, and `openai` to use them (`max_tokens`/`maxOutputTokens`/`max_completion_tokens`)
> - Adds clearer HTTP error messages (429, 503, 520–524) and preserves model-not-found detection
> 
> **Diff stats and prompt sizing**
> - Replaces `git_staged_changes` with `get_staged_changes` returning `StagedChanges { diff_text, stats }` and `DiffStats::print()`
> - Prints compact `Staged:` summary with per-file +/- counts and unstaged warning; skips noisy files (lockfiles, maps, minified, images, dist/build)
> - Adaptive trimming for large diffs (reduced context lines and per-file limits)
> - `main`: uses new API, shows stats unless suppressed, spinner includes model name, adaptively includes fewer/no recent commits for large diffs
> 
> **Analysis and UX tweaks**
> - `analysis` summary lists `Changed Files (top 20 by churn)` and appends `+N other files`
> - CLI defaults: `--context-lines` 8 (was 12), `--max-lines-per-file` 300 (was 500)
> - Integration script updated to assert new `Staged:` stats format
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f49193ff724eb033425a32e7d79bae16edaa3e73. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->