### PR TITLE
fix: find git repo when running from subdirectory

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -193,8 +193,8 @@ async fn main() {
     let cli_config = Config::from_args(&args);
     config.merge(&cli_config);
 
-    // Open git repository
-    let repo = match Repository::open(".") {
+    // Open git repository (discover searches up the directory tree)
+    let repo = match Repository::discover(".") {
         Ok(repo) => repo,
         Err(e) => {
             eprintln!("{}", "Error opening git repository:".red().bold());


### PR DESCRIPTION
## Summary
- Use `Repository::discover()` instead of `Repository::open()` to find the git repository
- This allows `cmt` to work when invoked from any subdirectory within a git repository, not just the root

## Test plan
- [x] Build passes
- [x] All tests pass
- [ ] Manual test: run `cmt` from a subdirectory of a git repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)