### PR TITLE
fix: use musl targets for Linux to support older glibc versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
+            target: x86_64-unknown-linux-musl
             asset_name: cmt-linux-amd64
           - os: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
+            target: aarch64-unknown-linux-musl
             asset_name: cmt-linux-arm64
           - os: macos-latest
             target: x86_64-apple-darwin


### PR DESCRIPTION
## Summary
- Switch Linux release builds from `x86_64-unknown-linux-gnu` to `x86_64-unknown-linux-musl`
- Switch `aarch64-unknown-linux-gnu` to `aarch64-unknown-linux-musl`
- Produces fully static binaries that work on any Linux system regardless of glibc version

## Problem
The current Linux binaries require glibc 2.38+, failing on systems with older glibc:
```
cmt: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by cmt)
```

## Solution
musl targets produce statically linked binaries with no glibc dependency, compatible with:
- Ubuntu 20.04, 22.04, and older
- Alpine Linux
- Any Linux distribution

## Test plan
- [ ] Verify release workflow builds successfully
- [ ] Test binary on system with glibc < 2.38

🤖 Generated with [Claude Code](https://claude.com/claude-code)