### PR TITLE
fix: Tier-0 correctness bugs (diff truncation, glob matching, scope, footers)

### DIFF
--- a/src/cmtignore.rs
+++ b/src/cmtignore.rs
@@ -62,68 +62,79 @@ pub fn append_to_cmtignore(repo_root: &Path, files: &[String]) -> io::Result<()>
     Ok(())
 }
 
-/// Check if a file path matches a .cmtignore pattern
+/// Check if a file path matches a .cmtignore pattern.
 ///
-/// Supports simple glob patterns:
-/// - `*` matches any sequence of characters (except `/`)
-/// - `**` matches any sequence of characters (including `/`)
-/// - Exact matches work as expected
+/// Patterns are matched component-by-component (split on `/`):
+/// - `*` matches any run of characters within a single path component (not `/`)
+/// - `?` matches any single character within a component
+/// - `**` matches zero or more whole path components (any depth)
+/// - everything else is a literal match
+///
+/// This supports multiple wildcards in one pattern (e.g. `src/*/*.rs`,
+/// `**/*.test.tsx`) and anchors `**` on component boundaries, so `**/foo.tsx`
+/// matches `a/b/foo.tsx` but not `barfoo.tsx`.
 pub fn matches_pattern(path: &str, pattern: &str) -> bool {
-    // Normalize path separators
     let path = path.replace('\\', "/");
     let pattern = pattern.replace('\\', "/");
 
-    // Handle ** glob (matches any path depth)
-    if pattern.contains("**") {
-        let parts: Vec<&str> = pattern.split("**").collect();
-        if parts.len() == 2 {
-            let prefix = parts[0];
-            let suffix = parts[1].trim_start_matches('/');
+    let pat: Vec<&str> = pattern.split('/').collect();
+    let segs: Vec<&str> = path.split('/').collect();
+    match_components(&pat, &segs)
+}
 
-            // Check if path starts with prefix (if any) and ends with suffix (if any)
-            let matches_prefix = prefix.is_empty() || path.starts_with(prefix);
-
-            // For suffix, we need to handle patterns like "*.tsx" - match against filename
-            let matches_suffix = if suffix.is_empty() {
-                true
-            } else if let Some(ext_pattern) = suffix.strip_prefix('*') {
-                // Suffix like "*.tsx" - check if any path component matches
-                // ext_pattern is e.g., ".tsx"
-                path.ends_with(ext_pattern)
+/// Match pattern components against path components. A `**` component matches
+/// zero or more path components; any other component is matched against a single
+/// path component via [`segment_match`].
+fn match_components(pat: &[&str], path: &[&str]) -> bool {
+    match pat.split_first() {
+        None => path.is_empty(),
+        Some((&first, rest)) => {
+            if first == "**" {
+                // Try consuming 0..=path.len() leading components.
+                (0..=path.len()).any(|i| match_components(rest, &path[i..]))
             } else {
-                path.ends_with(suffix)
-            };
-
-            return matches_prefix && matches_suffix;
-        }
-    }
-
-    // Handle * glob (matches within single path component)
-    if pattern.contains('*') {
-        let parts: Vec<&str> = pattern.split('*').collect();
-        if parts.len() == 2 {
-            let prefix = parts[0];
-            let suffix = parts[1];
-
-            // For single *, don't match across directory separators
-            let matches_prefix = path.starts_with(prefix);
-            let matches_suffix = path.ends_with(suffix);
-
-            if matches_prefix && matches_suffix {
-                // Check that the middle part doesn't contain /
-                let middle_start = prefix.len();
-                let middle_end = path.len().saturating_sub(suffix.len());
-                if middle_start <= middle_end {
-                    let middle = &path[middle_start..middle_end];
-                    return !middle.contains('/');
+                match path.split_first() {
+                    Some((&head, tail)) if segment_match(first, head) => {
+                        match_components(rest, tail)
+                    }
+                    _ => false,
                 }
             }
+        }
+    }
+}
+
+/// Glob-match a single path component: `*` matches any run of characters and `?`
+/// matches exactly one (neither crosses `/`, since components contain none).
+fn segment_match(pattern: &str, text: &str) -> bool {
+    let pat: Vec<char> = pattern.chars().collect();
+    let txt: Vec<char> = text.chars().collect();
+    let (mut pi, mut ti) = (0usize, 0usize);
+    let (mut star_pi, mut star_ti): (Option<usize>, usize) = (None, 0);
+
+    while ti < txt.len() {
+        if pi < pat.len() && (pat[pi] == '?' || pat[pi] == txt[ti]) {
+            pi += 1;
+            ti += 1;
+        } else if pi < pat.len() && pat[pi] == '*' {
+            // Record a backtracking point: `*` matches zero chars for now.
+            star_pi = Some(pi);
+            star_ti = ti;
+            pi += 1;
+        } else if let Some(sp) = star_pi {
+            // Backtrack: let the last `*` consume one more character.
+            pi = sp + 1;
+            star_ti += 1;
+            ti = star_ti;
+        } else {
             return false;
         }
     }
-
-    // Exact match
-    path == pattern
+    // Trailing `*`s match the empty string.
+    while pi < pat.len() && pat[pi] == '*' {
+        pi += 1;
+    }
+    pi == pat.len()
 }
 
 #[cfg(test)]
@@ -215,5 +226,30 @@ mod tests {
 
         assert!(matches_pattern("src/components/Button.tsx", "**/*.tsx"));
         assert!(matches_pattern("Button.tsx", "**/*.tsx"));
+    }
+
+    #[test]
+    fn test_matches_pattern_multiple_wildcards() {
+        // Patterns with 2+ wildcards previously fell through to exact match and
+        // silently matched nothing.
+        assert!(matches_pattern("src/a/file.rs", "src/*/*.rs"));
+        assert!(matches_pattern(
+            "src/components/Button.test.tsx",
+            "**/*.test.tsx"
+        ));
+        assert!(matches_pattern("a/b/c/d.rs", "a/**/d.rs"));
+        // `*` must not cross a directory separator.
+        assert!(!matches_pattern("src/a/b/file.rs", "src/*/*.rs"));
+    }
+
+    #[test]
+    fn test_matches_pattern_respects_component_boundaries() {
+        // `**/foo.tsx` must match on a component boundary, not a raw suffix.
+        assert!(matches_pattern("a/b/foo.tsx", "**/foo.tsx"));
+        assert!(matches_pattern("foo.tsx", "**/foo.tsx"));
+        assert!(!matches_pattern("barfoo.tsx", "**/foo.tsx"));
+        // A literal prefix must align with a component boundary too.
+        assert!(matches_pattern("src/x/y.tsx", "src/**/*.tsx"));
+        assert!(!matches_pattern("src-gen/y.tsx", "src/**/*.tsx"));
     }
 }

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -93,19 +93,30 @@ pub fn simple_template() -> String {
         .to_string()
 }
 
-/// Conventional commits template (triple braces to avoid HTML escaping)
+/// Conventional commits template (triple braces to avoid HTML escaping).
+///
+/// Renders the `issues` and `breaking` footers and the `!` breaking marker so
+/// the default template never silently drops fields the model populated.
 pub fn conventional_template() -> String {
-    r#"{{type}}{{#if scope}}({{{scope}}}){{/if}}: {{{subject}}}
+    r#"{{type}}{{#if scope}}({{{scope}}}){{/if}}{{#if breaking}}!{{/if}}: {{{subject}}}
 
 {{#if details}}
 {{{details}}}
+{{/if}}
+
+{{#if issues}}
+Fixes: {{{issues}}}
+{{/if}}
+
+{{#if breaking}}
+BREAKING CHANGE: {{{breaking}}}
 {{/if}}"#
         .to_string()
 }
 
 /// Detailed template (triple braces to avoid HTML escaping)
 pub fn detailed_template() -> String {
-    r#"{{type}}{{#if scope}}({{{scope}}}){{/if}}: {{{subject}}}
+    r#"{{type}}{{#if scope}}({{{scope}}}){{/if}}{{#if breaking}}!{{/if}}: {{{subject}}}
 
 {{#if details}}
 {{{details}}}

--- a/src/git.rs
+++ b/src/git.rs
@@ -186,6 +186,27 @@ pub struct StagedChanges {
     pub stats: DiffStats,
 }
 
+/// Append a diff content line to `out`, truncating it to `max_width` bytes on a
+/// UTF-8 character boundary (never mid-codepoint, which would panic) and
+/// preserving any trailing newline so the next line isn't merged onto the
+/// truncated one.
+fn push_diff_line(out: &mut String, content: &str, max_width: usize) {
+    if content.len() <= max_width {
+        out.push_str(content);
+        return;
+    }
+    // Largest char boundary <= max_width so we never slice mid-codepoint.
+    let mut end = max_width;
+    while end > 0 && !content.is_char_boundary(end) {
+        end -= 1;
+    }
+    out.push_str(&content[..end]);
+    out.push_str("...");
+    if content.ends_with('\n') {
+        out.push('\n');
+    }
+}
+
 fn is_skippable(path: &Path) -> bool {
     let name = path
         .file_name()
@@ -424,16 +445,27 @@ pub fn get_staged_changes(
         .map(|(f, _, _)| f.clone())
         .collect();
 
-    // Build diff text
+    // Build diff text. The line cap is applied PER FILE: we track the current
+    // file and reset the counter whenever the diff moves on to a new file, so a
+    // large early file can't consume the whole budget and starve later files
+    // out of the diff entirely.
     let mut diff_str = String::new();
-    let mut line_count = 0;
+    let mut line_count = 0usize;
     let mut truncated = false;
+    let mut current_file: Option<std::path::PathBuf> = None;
 
     diff.print(git2::DiffFormat::Patch, |delta, _, line| {
         let file_path = delta
             .new_file()
             .path()
             .unwrap_or_else(|| std::path::Path::new(""));
+
+        // Reset the per-file line budget when we reach a new file.
+        if current_file.as_deref() != Some(file_path) {
+            current_file = Some(file_path.to_path_buf());
+            line_count = 0;
+            truncated = false;
+        }
 
         // Skip .lock files and other auto-skippable files
         if is_skippable(file_path) {
@@ -451,13 +483,8 @@ pub fn get_staged_changes(
                 '+' | '-' | ' ' => {
                     // Preserve the prefix character for additions, deletions, and context
                     diff_str.push(line.origin());
-                    let line_content = std::str::from_utf8(line.content()).unwrap_or("binary");
-                    if line_content.len() > max_line_width {
-                        diff_str.push_str(&line_content[..max_line_width]);
-                        diff_str.push_str("...");
-                    } else {
-                        diff_str.push_str(line_content);
-                    }
+                    let line_content = std::str::from_utf8(line.content()).unwrap_or("");
+                    push_diff_line(&mut diff_str, line_content, max_line_width);
                     line_count += 1; // Increment line count only for content lines
                 }
                 _ => {
@@ -467,7 +494,7 @@ pub fn get_staged_changes(
             }
         } else if !truncated {
             truncated = true;
-            diff_str.push_str("\n[Note: Diff output truncated to max lines per file.]");
+            diff_str.push_str("\n[Note: Diff output truncated to max lines per file.]\n");
         }
         true
     })
@@ -686,6 +713,48 @@ mod tests {
         // Assert that the line is truncated to max_line_width
         assert!(staged.diff_text.contains(&long_line[..max_line_width]));
         assert!(staged.diff_text.contains("..."));
+    }
+
+    #[test]
+    fn test_max_line_width_utf8_does_not_panic() {
+        let (_temp_dir, repo) = setup_test_repo();
+
+        // A long line of 2-byte chars; an odd byte-width cut lands mid-codepoint,
+        // which a raw byte slice would panic on.
+        let long_line = "é".repeat(400);
+        create_and_stage_file(&repo, "test.txt", &long_line);
+
+        let max_line_width = 101;
+        let staged = get_staged_changes(&repo, 0, 100, max_line_width, 0, &[]).unwrap();
+
+        // Must truncate without panicking.
+        assert!(staged.diff_text.contains("..."));
+    }
+
+    #[test]
+    fn test_max_lines_per_file_is_per_file_not_global() {
+        let (_temp_dir, repo) = setup_test_repo();
+
+        // First file alone exceeds the cap; a second file follows it.
+        let mut big = String::new();
+        for i in 0..50 {
+            big.push_str(&format!("alpha {}\n", i));
+        }
+        create_and_stage_file(&repo, "a_first.txt", &big);
+        create_and_stage_file(&repo, "z_second.txt", "unique-second-file-marker\n");
+
+        let staged = get_staged_changes(&repo, 0, 10, 300, 0, &[]).unwrap();
+
+        // The first file is truncated...
+        assert!(staged
+            .diff_text
+            .contains("[Note: Diff output truncated to max lines per file.]"));
+        // ...but the cap is per-file, so the second file is NOT starved out.
+        assert!(
+            staged.diff_text.contains("unique-second-file-marker"),
+            "second file content should survive a per-file cap; diff was:\n{}",
+            staged.diff_text
+        );
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,31 +55,35 @@ fn validate_commit_data(mut data: CommitTemplate) -> CommitTemplate {
     // Validate scope (lowercase, no spaces)
     if let Some(ref mut scope) = data.scope {
         *scope = scope.to_lowercase().replace(' ', "-");
-        // Remove scope if it's too generic, empty, or literally "null"
+        // Remove scope if it's too generic, empty, or a placeholder value the
+        // model sometimes emits ("null"/"none") that would render as `(none)`.
         if scope.is_empty()
             || scope == "general"
             || scope == "misc"
             || scope == "other"
             || scope == "null"
+            || scope == "none"
         {
             data.scope = None;
         }
     }
 
-    // Clean up details - remove bullets that duplicate subject
+    // Clean up details - drop only bullets that are an exact echo of the
+    // subject. The previous substring logic treated an empty line as "contained
+    // in the subject" (and any bullet that happened to be a substring), so it
+    // could delete blank separators and legitimate bullets, corrupting the body.
     if let Some(ref mut details) = data.details {
-        let subject_lower = data.subject.to_lowercase();
+        let subject_norm = data.subject.trim().to_lowercase();
         let lines: Vec<&str> = details
             .lines()
             .filter(|line| {
-                let line_lower = line.to_lowercase();
-                // Keep line if it's not too similar to subject
-                !line_lower.contains(&subject_lower)
-                    && !subject_lower.contains(line_lower.trim_start_matches("- "))
+                let bullet = line.trim().trim_start_matches("- ").trim().to_lowercase();
+                // Keep blank lines and anything that isn't an exact subject echo.
+                bullet.is_empty() || bullet != subject_norm
             })
             .collect();
 
-        if lines.is_empty() {
+        if lines.iter().all(|l| l.trim().is_empty()) {
             data.details = None;
         } else {
             *details = lines.join("\n");
@@ -337,5 +341,28 @@ mod tests {
         assert!(validated.scope.is_none());
         // Details that duplicate subject should be removed
         assert!(validated.details.is_some());
+    }
+
+    #[test]
+    fn test_validate_drops_none_scope_and_preserves_body() {
+        let data = CommitTemplate {
+            commit_type: templates::CommitType::Feat,
+            subject: "add caching layer".to_string(),
+            details: Some("- add caching layer\n\n- expire entries after 24h".to_string()),
+            issues: None,
+            breaking: None,
+            scope: Some("none".to_string()),
+        };
+
+        let validated = validate_commit_data(data);
+
+        // "none" is a placeholder scope and must be dropped (no `(none)` output).
+        assert!(validated.scope.is_none());
+
+        // The exact subject echo is dropped, but the legitimate bullet survives
+        // (the old substring dedup could have wiped the whole body).
+        let details = validated.details.expect("body should not be emptied");
+        assert!(details.contains("- expire entries after 24h"));
+        assert!(!details.contains("- add caching layer"));
     }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -251,7 +251,7 @@ impl TemplateManager {
         }
 
         let rendered = self.handlebars.render(template_name, &json!(data))?;
-        Ok(rendered)
+        Ok(normalize_message(&rendered))
     }
 
     /// Get a list of available templates
@@ -304,6 +304,27 @@ impl TemplateManager {
     }
 }
 
+/// Normalize a rendered commit message: collapse any run of 3+ newlines into a
+/// single blank-line separator and trim trailing whitespace. Optional template
+/// sections (`{{#if issues}}`, `{{#if breaking}}`) leave blank lines when empty;
+/// this keeps the output tidy regardless of which fields are present.
+fn normalize_message(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut newlines = 0usize;
+    for ch in s.chars() {
+        if ch == '\n' {
+            newlines += 1;
+            if newlines <= 2 {
+                out.push('\n');
+            }
+        } else {
+            newlines = 0;
+            out.push(ch);
+        }
+    }
+    out.trim_end().to_string()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -350,8 +371,9 @@ mod tests {
             ..Default::default()
         };
 
+        // Trailing whitespace from the empty {{#if details}} block is trimmed.
         let rendered = manager.render("test", &data_with_scope).unwrap();
-        assert_eq!(rendered, "feat: add new feature (ui)\n\n");
+        assert_eq!(rendered, "feat: add new feature (ui)");
 
         // Without scope
         let data_without_scope = CommitTemplate {
@@ -361,7 +383,50 @@ mod tests {
         };
 
         let rendered = manager.render("test", &data_without_scope).unwrap();
-        assert_eq!(rendered, "feat: add new feature\n\n");
+        assert_eq!(rendered, "feat: add new feature");
+    }
+
+    #[test]
+    fn test_conventional_template_renders_issues_and_breaking() {
+        let mut manager = TemplateManager {
+            handlebars: Handlebars::new(),
+            templates: HashMap::new(),
+        };
+        manager
+            .register_template(
+                "conventional",
+                &crate::config::defaults::conventional_template(),
+            )
+            .unwrap();
+
+        let data = CommitTemplate {
+            commit_type: CommitType::Feat,
+            subject: "drop legacy auth".to_string(),
+            details: Some("- remove the /v1/login endpoint".to_string()),
+            issues: Some("#42".to_string()),
+            breaking: Some("removes the /v1/login endpoint".to_string()),
+            scope: None,
+        };
+
+        let rendered = manager.render("conventional", &data).unwrap();
+
+        // The default template must NOT drop the issues/breaking fields, and a
+        // breaking change must carry the `!` marker per the Conventional spec.
+        assert!(
+            rendered.starts_with("feat!:"),
+            "breaking `!` marker missing: {rendered:?}"
+        );
+        assert!(rendered.contains("- remove the /v1/login endpoint"));
+        assert!(
+            rendered.contains("Fixes: #42"),
+            "issues footer missing: {rendered:?}"
+        );
+        assert!(
+            rendered.contains("BREAKING CHANGE: removes the /v1/login endpoint"),
+            "breaking footer missing: {rendered:?}"
+        );
+        // No trailing blank lines.
+        assert!(!rendered.ends_with('\n'), "should be trimmed: {rendered:?}");
     }
 
     #[test]


### PR DESCRIPTION
Fixes six confirmed correctness bugs from the first-principles review, each one reachable on ordinary input and now covered by a regression test. These are the surgical, self-contained fixes; the two Tier-0 bugs whose *correct* fix is architectural — the **dead config-file system** (fixed by-construction via a resolved `Settings` seam) and **`analysis.rs` scrambled stats** (slated for deletion) — are deferred to the follow-up refactor PR.

## Bugs fixed

| Area | Bug | Fix |
|------|-----|-----|
| `git.rs` | `max_lines_per_file` was a **global** cap (counter never reset per file) → large early files starved later files out of the diff | Reset the counter per file |
| `git.rs` | Truncating a wide line sliced `&str` by raw byte offset → **panic mid-codepoint** (accents/CJK/emoji) | Truncate on a char boundary; preserve trailing newline |
| `defaults.rs` / `templates.rs` | The **default** `conventional` template dropped `issues` **and** `breaking` → no `BREAKING CHANGE:` footer by default | Render footers + `!` marker; normalize blank lines |
| `lib.rs` | Scope `"none"` rendered as `feat(none):` | Added to the generic-scope filter |
| `lib.rs` | Detail dedup used substring containment → could delete blank lines / corrupt the body | Drop only exact subject echoes |
| `cmtignore.rs` | `matches_pattern` silently no-op'd on 2+ wildcards (`src/*/*.rs`) and matched `**/foo.tsx` by raw suffix | Component-based glob matcher (`*`/`?`/`**`) |

## Validation

- `cargo fmt --check` ✅ &nbsp; `cargo clippy --locked --all-targets -- -D warnings` ✅
- `cargo test --locked --no-fail-fast` ✅ — **92 lib tests** (+6 new regressions) and **5 live integration tests** pass
- End-to-end dogfood ✅ — `cmt` generates a clean message (no more `feat(none):`)

### New regression tests
- `git::test_max_lines_per_file_is_per_file_not_global`
- `git::test_max_line_width_utf8_does_not_panic`
- `templates::test_conventional_template_renders_issues_and_breaking`
- `test_validate_drops_none_scope_and_preserves_body`
- `cmtignore::test_matches_pattern_multiple_wildcards`
- `cmtignore::test_matches_pattern_respects_component_boundaries`

🤖 Generated with [Claude Code](https://claude.com/claude-code)