### PR TITLE
chore: harden install script and Homebrew release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,33 +136,47 @@ jobs:
         run: |
           VERSION=${{ steps.get_version.outputs.VERSION }}
 
-          # Wait for all assets to be available
+          # The Homebrew formula references all four non-Windows binaries, so we
+          # must wait for the complete set before computing SHAs. Waiting for
+          # only 4 (or letting a download silently fail) could emit a formula
+          # with an empty sha256, which is broken and hard to recover from.
+          EXPECTED_ASSETS=5
           echo "Waiting for release assets..."
           for i in {1..30}; do
             ASSET_COUNT=$(gh release view "v$VERSION" --json assets --jq '.assets | length')
-            if [ "$ASSET_COUNT" -ge 4 ]; then
+            if [ "$ASSET_COUNT" -ge "$EXPECTED_ASSETS" ]; then
               echo "Found $ASSET_COUNT assets"
               break
             fi
-            echo "Found $ASSET_COUNT assets, waiting... ($i/30)"
+            echo "Found $ASSET_COUNT assets, waiting for $EXPECTED_ASSETS... ($i/30)"
             sleep 10
           done
 
-          # Download and compute SHA256 for each binary
-          gh release download "v$VERSION" -p "cmt-darwin-arm64" -D /tmp
-          gh release download "v$VERSION" -p "cmt-darwin-amd64" -D /tmp
-          gh release download "v$VERSION" -p "cmt-linux-arm64" -D /tmp || true
-          gh release download "v$VERSION" -p "cmt-linux-amd64" -D /tmp || true
+          # Download every binary the formula needs. No `|| true`: a missing
+          # asset must fail the job rather than silently produce an empty SHA.
+          for asset in cmt-darwin-arm64 cmt-darwin-amd64 cmt-linux-arm64 cmt-linux-amd64; do
+            gh release download "v$VERSION" -p "$asset" -D /tmp
+          done
 
-          echo "SHA_DARWIN_ARM64=$(sha256sum /tmp/cmt-darwin-arm64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          echo "SHA_DARWIN_AMD64=$(sha256sum /tmp/cmt-darwin-amd64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
+          SHA_DARWIN_ARM64=$(sha256sum /tmp/cmt-darwin-arm64 | cut -d' ' -f1)
+          SHA_DARWIN_AMD64=$(sha256sum /tmp/cmt-darwin-amd64 | cut -d' ' -f1)
+          SHA_LINUX_ARM64=$(sha256sum /tmp/cmt-linux-arm64 | cut -d' ' -f1)
+          SHA_LINUX_AMD64=$(sha256sum /tmp/cmt-linux-amd64 | cut -d' ' -f1)
 
-          if [ -f /tmp/cmt-linux-arm64 ]; then
-            echo "SHA_LINUX_ARM64=$(sha256sum /tmp/cmt-linux-arm64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          fi
-          if [ -f /tmp/cmt-linux-amd64 ]; then
-            echo "SHA_LINUX_AMD64=$(sha256sum /tmp/cmt-linux-amd64 | cut -d' ' -f1)" >> $GITHUB_OUTPUT
-          fi
+          # Refuse to proceed with a missing/empty SHA.
+          for sha in "$SHA_DARWIN_ARM64" "$SHA_DARWIN_AMD64" "$SHA_LINUX_ARM64" "$SHA_LINUX_AMD64"; do
+            if [ -z "$sha" ]; then
+              echo "Error: computed an empty SHA256 - refusing to write a broken formula"
+              exit 1
+            fi
+          done
+
+          {
+            echo "SHA_DARWIN_ARM64=$SHA_DARWIN_ARM64"
+            echo "SHA_DARWIN_AMD64=$SHA_DARWIN_AMD64"
+            echo "SHA_LINUX_ARM64=$SHA_LINUX_ARM64"
+            echo "SHA_LINUX_AMD64=$SHA_LINUX_AMD64"
+          } >> $GITHUB_OUTPUT
 
       - name: Update Homebrew formula
         env:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -65,9 +65,21 @@ echo "Installing cmt ${LATEST_VERSION} for ${PLATFORM} ${ARCH}"
 TMP_DIR=$(mktemp -d)
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-# Download binary
+# Download binary.
+# -f makes curl exit non-zero on HTTP errors (e.g. 404) instead of writing an
+# HTML error page to the output file and "installing" it as the binary.
 DOWNLOAD_URL="https://github.com/clifton/cmt/releases/download/${LATEST_VERSION}/${BINARY}"
-eval curl -sL $CURL_HEADERS "$DOWNLOAD_URL" -o "$TMP_DIR/$BINARY"
+if ! eval curl -fSL $CURL_HEADERS "$DOWNLOAD_URL" -o "$TMP_DIR/$BINARY"; then
+    echo "Error: failed to download $BINARY from $DOWNLOAD_URL"
+    echo "       (no prebuilt binary for ${PLATFORM} ${ARCH} in ${LATEST_VERSION}?)"
+    exit 1
+fi
+
+# Sanity-check the download before trusting it.
+if [ ! -s "$TMP_DIR/$BINARY" ]; then
+    echo "Error: downloaded file is empty"
+    exit 1
+fi
 
 # Make binary executable
 chmod +x "$TMP_DIR/$BINARY"


### PR DESCRIPTION
Two supply-chain/release robustness fixes from the review (independent of the other PRs).

## `scripts/install.sh`
`curl -sL` (no `-f`) means an HTTP error response (e.g. a 404 for a platform with no prebuilt binary) is written to the output file, then `chmod +x`'d and installed as `cmt`. Now uses `curl -fSL`, aborts on download failure with a clear message, and rejects an empty file before trusting it.

## `.github/workflows/release.yml`
The Homebrew formula always references the four non-Windows binaries, but the update-homebrew job waited for only **4 of 5** assets and downloaded the Linux binaries with `|| true`. If a Linux asset wasn't uploaded yet, `SHA_LINUX_*` stayed empty and the published formula got `sha256 ""` — broken and painful to recover from. Now it waits for all 5 assets, downloads without `|| true`, and hard-fails if any computed SHA is empty.

## Validation
- `sh -n scripts/install.sh` ✅ &nbsp; `release.yml` YAML parses ✅
- The `test-install` CI workflow exercises the install script on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)