### PR TITLE
feat: redact likely secrets from the diff before sending it to the LLM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,7 @@ dependencies = [
  "git2",
  "handlebars",
  "indicatif",
+ "regex",
  "reqwest",
  "rstructor",
  "serde",
@@ -1711,6 +1712,18 @@ dependencies = [
  "getrandom 0.2.17",
  "libredox",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ toml = "1.0.2+spec-1.1.0"
 indicatif = "0.18.4"
 arboard = "3.6.1"
 dirs = "6.0.0"
+regex = "1.11"
 
 # AI structured output
 rstructor = { version = "0.2.11", features = ["openai", "anthropic", "gemini"] }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -306,7 +306,24 @@ async fn main() {
         }
     }
 
-    let staged_changes = staged.diff_text.clone();
+    // Scrub likely secrets from the diff before it ever leaves the machine.
+    let staged_changes = if config.redact {
+        let (scrubbed, redacted) = cmt::redact_secrets(&staged.diff_text);
+        if redacted > 0 && !config.message_only {
+            eprintln!(
+                "{}",
+                format!(
+                    "🔒 Redacted {} likely secret{} from the diff before sending it to the model (disable with --no-redact).",
+                    redacted,
+                    if redacted == 1 { "" } else { "s" }
+                )
+                .yellow()
+            );
+        }
+        scrubbed
+    } else {
+        staged.diff_text.clone()
+    };
 
     // Determine diff size for adaptive behaviors (very high thresholds - Gemini supports 1M tokens)
     let is_very_large_diff = staged.stats.files_changed > 150

--- a/src/config/cli.rs
+++ b/src/config/cli.rs
@@ -16,6 +16,10 @@ pub struct Args {
     #[arg(long, default_value_t = false)]
     pub show_raw_diff: bool,
 
+    /// Do not scrub likely secrets (API keys, tokens, private keys) from the diff
+    #[arg(long, default_value_t = false)]
+    pub no_redact: bool,
+
     /// Number of context lines to show in the git diff
     #[arg(long, default_value_t = 20)]
     pub context_lines: u32,

--- a/src/config/defaults.rs
+++ b/src/config/defaults.rs
@@ -16,6 +16,7 @@ pub const CMTIGNORE_FILENAME: &str = ".cmtignore";
 pub const DEFAULT_PROVIDER: &str = "gemini";
 pub const DEFAULT_THINKING: &str = "low"; // Reasoning depth: none, minimal, low, high
 pub const TIMEOUT_SECS: u64 = 60; // Per-request timeout (seconds) for the LLM call
+pub const REDACT: bool = true; // Scrub likely secrets from the diff before sending it
 
 // Git defaults
 pub const INCLUDE_RECENT_COMMITS: bool = true;
@@ -51,6 +52,7 @@ pub fn example_config() -> String {
 message_only = {}
 no_diff_stats = {}
 show_raw_diff = {}
+redact = {}  # Scrub likely secrets (keys, tokens, private keys) from the diff
 context_lines = {}
 max_lines_per_file = {}
 max_line_width = {}
@@ -76,6 +78,7 @@ recent_commits_count = {}
         MESSAGE_ONLY,
         NO_DIFF_STATS,
         SHOW_RAW_DIFF,
+        REDACT,
         CONTEXT_LINES,
         MAX_LINES_PER_FILE,
         MAX_LINE_WIDTH,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -48,6 +48,7 @@ pub struct Config {
     pub message_only: bool,
     pub no_diff_stats: bool,
     pub show_raw_diff: bool,
+    pub redact: bool,
     pub context_lines: u32,
     pub max_lines_per_file: usize,
     pub max_line_width: usize,
@@ -77,6 +78,7 @@ impl Default for Config {
             message_only: defaults::MESSAGE_ONLY,
             no_diff_stats: defaults::NO_DIFF_STATS,
             show_raw_diff: defaults::SHOW_RAW_DIFF,
+            redact: defaults::REDACT,
             context_lines: defaults::CONTEXT_LINES,
             max_lines_per_file: defaults::MAX_LINES_PER_FILE,
             max_line_width: defaults::MAX_LINE_WIDTH,
@@ -155,6 +157,9 @@ impl Config {
         if other.show_raw_diff != defaults::SHOW_RAW_DIFF {
             self.show_raw_diff = other.show_raw_diff;
         }
+        if other.redact != defaults::REDACT {
+            self.redact = other.redact;
+        }
         if other.context_lines != defaults::CONTEXT_LINES {
             self.context_lines = other.context_lines;
         }
@@ -202,6 +207,7 @@ impl Config {
             message_only: args.message_only,
             no_diff_stats: args.no_diff_stats,
             show_raw_diff: args.show_raw_diff,
+            redact: !args.no_redact,
             context_lines: args.context_lines,
             max_lines_per_file: args.max_lines_per_file,
             max_line_width: args.max_line_width,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@ mod git;
 pub mod pricing;
 mod progress;
 mod prompts;
+mod redact;
 mod templates;
 
 pub use cmtignore::{append_to_cmtignore, load_cmtignore};
+pub use redact::redact_secrets;
 
 pub use commit::{create_commit, CommitError, CommitOptions, CommitResult};
 

--- a/src/redact.rs
+++ b/src/redact.rs
@@ -1,0 +1,206 @@
+//! Redact likely secrets from the diff before it is sent to a third-party LLM.
+//!
+//! `.cmtignore` is path-based, so a credential hardcoded *inside* an otherwise
+//! legitimate staged file (an accidentally-staged `.env`, an AWS key, a GitHub
+//! token, a private key block) would still be sent to the model. This pass
+//! scrubs high-precision secret patterns from the diff text, replacing them
+//! with `[REDACTED]`. It is deliberately conservative (named, structured tokens
+//! plus `key = value` assignments) to keep false positives low, and can be
+//! disabled with `--no-redact`.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+const PLACEHOLDER: &str = "[REDACTED]";
+
+/// Patterns whose entire match is a secret and is replaced wholesale.
+fn full_match_patterns() -> &'static [Regex] {
+    static PATTERNS: OnceLock<Vec<Regex>> = OnceLock::new();
+    PATTERNS.get_or_init(|| {
+        [
+            // AWS access key id
+            r"AKIA[0-9A-Z]{16}",
+            // GitHub tokens (ghp_, gho_, ghu_, ghs_, ghr_)
+            r"\bgh[pousr]_[A-Za-z0-9]{36,}\b",
+            // GitLab personal access token
+            r"\bglpat-[A-Za-z0-9_-]{20,}\b",
+            // Slack tokens
+            r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b",
+            // OpenAI-style keys
+            r"\bsk-[A-Za-z0-9_-]{20,}\b",
+            // JWT (header.payload.signature)
+            r"\beyJ[A-Za-z0-9_-]{6,}\.eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\b",
+        ]
+        .iter()
+        .map(|p| Regex::new(p).expect("valid secret regex"))
+        .collect()
+    })
+}
+
+/// `key = "value"` style assignment: capture 1 keeps the key + separator (+ any
+/// opening quote), capture 2 is the secret value that gets replaced.
+fn assignment_pattern() -> &'static Regex {
+    static PATTERN: OnceLock<Regex> = OnceLock::new();
+    PATTERN.get_or_init(|| {
+        Regex::new(
+            r#"(?i)((?:api[_-]?key|secret|client[_-]?secret|access[_-]?key|auth[_-]?token|token|password|passwd)["']?\s*[:=]\s*["']?)([A-Za-z0-9+/_\-]{12,})"#,
+        )
+        .expect("valid assignment regex")
+    })
+}
+
+/// Redact likely secrets from `input`. Returns the scrubbed text and the number
+/// of redactions made.
+pub fn redact_secrets(input: &str) -> (String, usize) {
+    let mut count = 0usize;
+    let mut out = String::with_capacity(input.len());
+    let mut in_pem = false;
+
+    for line in input.split_inclusive('\n') {
+        let (line_out, n, next_pem) = redact_line(line, in_pem);
+        count += n;
+        in_pem = next_pem;
+        out.push_str(&line_out);
+    }
+
+    (out, count)
+}
+
+/// Redact a single line, tracking whether we are inside a multi-line PEM private
+/// key block (whose base64 body lines aren't caught by the token patterns).
+fn redact_line(line: &str, in_pem: bool) -> (String, usize, bool) {
+    let is_private_key_marker = line.contains("PRIVATE KEY-----");
+
+    if in_pem {
+        if is_private_key_marker && line.contains("END") {
+            // Keep the END marker; leave the block.
+            return (line.to_string(), 0, false);
+        }
+        // Redact the base64 body line, preserving a diff prefix and newline.
+        return (redact_body_line(line), 1, true);
+    }
+
+    if is_private_key_marker && line.contains("BEGIN") {
+        // Keep the BEGIN marker (not itself a secret) and enter the block.
+        return (line.to_string(), 0, true);
+    }
+
+    let mut s = line.to_string();
+    let mut n = 0usize;
+
+    for re in full_match_patterns() {
+        let matches = re.find_iter(&s).count();
+        if matches > 0 {
+            n += matches;
+            s = re.replace_all(&s, PLACEHOLDER).into_owned();
+        }
+    }
+
+    let re = assignment_pattern();
+    let matches = re.find_iter(&s).count();
+    if matches > 0 {
+        n += matches;
+        s = re
+            .replace_all(&s, |caps: &regex::Captures| {
+                format!("{}{}", &caps[1], PLACEHOLDER)
+            })
+            .into_owned();
+    }
+
+    (s, n, false)
+}
+
+/// Replace a line's content with the placeholder while preserving a leading diff
+/// marker (`+`/`-`/space) and any trailing newline.
+fn redact_body_line(line: &str) -> String {
+    let (newline, body) = match line.strip_suffix('\n') {
+        Some(rest) => ("\n", rest),
+        None => ("", line),
+    };
+    let prefix = match body.chars().next() {
+        Some(c @ ('+' | '-' | ' ')) => &body[..c.len_utf8()],
+        _ => "",
+    };
+    format!("{prefix}{PLACEHOLDER}{newline}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_redacts_named_tokens() {
+        let cases = [
+            "+const key = AKIA1234567890ABCDEF;",
+            "+ghp_0123456789012345678901234567890123456789",
+            "+token: glpat-abcdefabcdefabcdef1234",
+            "+let s = \"sk-abcdefghijklmnopqrstuvwxyz0123\";",
+        ];
+        for c in cases {
+            let (out, n) = redact_secrets(c);
+            assert!(n >= 1, "expected redaction in: {c}");
+            assert!(out.contains(PLACEHOLDER), "no placeholder in: {out}");
+        }
+    }
+
+    #[test]
+    fn test_redacts_assignment_value_keeps_key() {
+        let (out, n) = redact_secrets("+API_KEY = \"s3cr3tvalue1234567890\"");
+        assert_eq!(n, 1);
+        assert!(out.contains("API_KEY"), "key name should survive: {out}");
+        assert!(out.contains(PLACEHOLDER), "value should be redacted: {out}");
+        assert!(
+            !out.contains("s3cr3tvalue1234567890"),
+            "secret leaked: {out}"
+        );
+    }
+
+    #[test]
+    fn test_redacts_jwt() {
+        let jwt =
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3OCJ9.SflKxwRJSMeKKF2QT4fwpM";
+        let (out, n) = redact_secrets(&format!("+const auth = {jwt};"));
+        assert!(n >= 1, "JWT should be redacted: {out}");
+        assert!(out.contains(PLACEHOLDER));
+        assert!(!out.contains("eyJzdWIi"), "JWT payload leaked: {out}");
+    }
+
+    #[test]
+    fn test_redacts_pem_block_body() {
+        let diff = "\
++-----BEGIN RSA PRIVATE KEY-----
++MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDexample
++abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345
++-----END RSA PRIVATE KEY-----
+";
+        let (out, n) = redact_secrets(diff);
+        assert!(n >= 2, "both body lines should be redacted: {out}");
+        // Markers are kept so the reader knows a key was present.
+        assert!(out.contains("BEGIN RSA PRIVATE KEY"));
+        assert!(out.contains("END RSA PRIVATE KEY"));
+        // Key material is gone.
+        assert!(!out.contains("MIIEvQIBAD"), "key body leaked: {out}");
+        // Diff prefix preserved on redacted body lines.
+        assert!(out.lines().any(|l| l == format!("+{PLACEHOLDER}")));
+    }
+
+    #[test]
+    fn test_leaves_ordinary_diff_untouched() {
+        let diff = "\
++fn add(a: i32, b: i32) -> i32 {
++    a + b
++}
+-let x = 42;
+";
+        let (out, n) = redact_secrets(diff);
+        assert_eq!(n, 0, "no false positives expected");
+        assert_eq!(out, diff);
+    }
+
+    #[test]
+    fn test_short_values_not_redacted() {
+        // A short token=... assignment shouldn't trip the 12+ char value rule.
+        let (out, n) = redact_secrets("+token = \"abc\"");
+        assert_eq!(n, 0, "short value should not be redacted: {out}");
+    }
+}


### PR DESCRIPTION
The research's top **security** recommendation, and a clear differentiator (no surveyed commit tool does this). cmt sends the full staged diff as the sole input to a third-party model, and `.cmtignore` is path-based — so a credential hardcoded *inside* an otherwise legitimate staged file (an accidentally-staged `.env`, an AWS key, a GitHub token, a private-key block) would be sent verbatim. This adds a redaction pass.

## What it catches
- AWS `AKIA…` access keys; GitHub (`ghp_`/`gho_`/…), GitLab (`glpat-`), Slack (`xox…`), OpenAI (`sk-…`) tokens; JWTs.
- Multi-line **PEM private-key blocks** — markers kept (so you can see a key was present), body redacted.
- `key = value` assignments for `api_key`/`secret`/`token`/`password`/… — the **key name is kept, the value is redacted**.

Each match becomes `[REDACTED]`. Conservative by design (12+ char values) to limit false positives.

## UX
- **On by default**; `--no-redact` (config `redact = false`) opts out.
- A one-line stderr notice reports how many secrets were scrubbed.
- `--show-raw-diff` shows the **redacted** diff — exactly what is sent to the model.

## Validation
- `cargo fmt --check` ✅ · `clippy --all-targets -D warnings` ✅ · `cargo test --lib` ✅ (95, incl. 6 redaction tests)
- Dogfood ✅ — planted `AKIAIOSFODNN7EXAMPLE` + an `api_key="…"`; both replaced with `[REDACTED]` in `--show-raw-diff`, secrets absent from output, notice printed.

Adds the `regex` dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)