### PR TITLE
feat: prepare-commit-msg git hook integration (cmt hook install)

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,20 @@ cmt --provider openai -t 0.8
 git commit -F <(cmt -m)
 ```
 
+## Git Hook Integration
+
+Install a `prepare-commit-msg` hook so cmt fills in the message for **plain `git commit`** — including IDE, `git gui`, and lazygit commit boxes — without typing `cmt`:
+
+```bash
+cmt hook install     # from inside the repo
+cmt hook uninstall   # remove it later
+```
+
+- Installs into `core.hooksPath` if set (Husky-compatible), otherwise `.git/hooks`, and coexists with any existing `prepare-commit-msg` hook (its block is marker-delimited).
+- Only fills a **fresh, empty** commit message. It deliberately skips `git commit -m`, `-t <template>`, merges, squashes, and amends so it never clobbers a message you supplied.
+- It **never blocks a commit**: if the API key is missing or the request fails, the hook exits cleanly and leaves the message untouched.
+- Secrets are still redacted (see below) before anything is sent to the model.
+
 ## How It Works
 
 1. `cmt` gathers rich context: README excerpt, branch name, recent commits

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -95,10 +95,159 @@ fn clean_edited_message(edited: &str) -> Option<String> {
     }
 }
 
+/// Handle `cmt hook <install|uninstall>`.
+fn hook_command(args: &[String]) {
+    let repo = match Repository::discover(".") {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("{}", "Error opening git repository:".red().bold());
+            eprintln!("{}", e);
+            process::exit(1);
+        }
+    };
+
+    match args.first().map(String::as_str) {
+        Some("install") => match cmt::hook::install(&repo) {
+            Ok(path) => {
+                println!(
+                    "{}",
+                    format!(
+                        "✓ Installed cmt prepare-commit-msg hook: {}",
+                        path.display()
+                    )
+                    .green()
+                    .bold()
+                );
+                println!(
+                    "{}",
+                    "Plain `git commit` (and IDE/lazygit commit boxes) will now auto-fill the message."
+                        .dimmed()
+                );
+            }
+            Err(e) => {
+                eprintln!("{}", "Error installing hook:".red().bold());
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        },
+        Some("uninstall") => match cmt::hook::uninstall(&repo) {
+            Ok(true) => println!(
+                "{}",
+                "✓ Removed cmt prepare-commit-msg hook.".green().bold()
+            ),
+            Ok(false) => println!("{}", "No cmt hook was installed.".yellow()),
+            Err(e) => {
+                eprintln!("{}", "Error removing hook:".red().bold());
+                eprintln!("{}", e);
+                process::exit(1);
+            }
+        },
+        _ => {
+            eprintln!("{}", "usage: cmt hook <install|uninstall>".yellow());
+            process::exit(2);
+        }
+    }
+}
+
+/// Git-invoked `prepare-commit-msg` hook: args are [msg_file, source, sha].
+///
+/// Generates a message and writes it into the commit-message file. ALWAYS exits
+/// 0 — a commit-message helper must never block the user's commit.
+async fn prepare_commit_msg(args: &[String]) {
+    let msg_file = match args.first() {
+        Some(f) => f,
+        None => process::exit(0),
+    };
+    let source = args.get(1).map(String::as_str);
+
+    // Only generate for a fresh, source-less commit (not -m/-t/merge/squash/amend).
+    if !cmt::hook::hook_should_generate(source) {
+        process::exit(0);
+    }
+
+    if let Some(message) = generate_for_hook().await {
+        // Prepend the generated message above git's comment block (git strips
+        // the comments on save); never discard whatever git already wrote.
+        let existing = std::fs::read_to_string(msg_file).unwrap_or_default();
+        let combined = format!("{}\n\n{}", message, existing);
+        let _ = std::fs::write(msg_file, combined);
+    }
+    process::exit(0);
+}
+
+/// Best-effort message generation for hook mode. Returns None on any failure
+/// (missing key, no staged changes, API error) so the caller can leave the
+/// commit message untouched rather than blocking the commit.
+async fn generate_for_hook() -> Option<String> {
+    let repo = Repository::discover(".").ok()?;
+    let config = Config::load().unwrap_or_default();
+
+    let repo_root = repo.workdir().unwrap_or_else(|| std::path::Path::new("."));
+    let cmtignore_patterns = load_cmtignore(repo_root);
+
+    let staged = cmt::get_staged_changes(
+        &repo,
+        config.context_lines,
+        config.max_lines_per_file,
+        config.max_line_width,
+        config.max_file_lines,
+        &cmtignore_patterns,
+    )
+    .ok()?;
+
+    let diff = if config.redact {
+        cmt::redact_secrets(&staged.diff_text).0
+    } else {
+        staged.diff_text
+    };
+    if diff.trim().is_empty() {
+        return None;
+    }
+
+    let recent = if config.include_recent_commits {
+        cmt::get_recent_commits(&repo, config.recent_commits_count).unwrap_or_default()
+    } else {
+        String::new()
+    };
+    let branch = get_current_branch(&repo);
+    let readme = get_readme_excerpt(&repo, 50);
+    let template_manager = TemplateManager::new().ok()?;
+
+    let result = generate_commit_message(
+        &config,
+        &diff,
+        &recent,
+        branch.as_deref(),
+        readme.as_deref(),
+        &template_manager,
+    )
+    .await
+    .ok()?;
+
+    Some(result.message)
+}
+
 #[tokio::main]
 async fn main() {
     dotenv().ok(); // Load .env file if it exists
-    let args = Args::new_from(env::args());
+
+    // Subcommand dispatch (kept out of the clap flag struct so plain `cmt` is
+    // unchanged): `cmt hook <install|uninstall>` and the git-invoked
+    // `cmt prepare-commit-msg <file> <source> <sha>`.
+    let argv: Vec<String> = env::args().collect();
+    match argv.get(1).map(String::as_str) {
+        Some("hook") => {
+            hook_command(&argv[2..]);
+            return;
+        }
+        Some("prepare-commit-msg") => {
+            prepare_commit_msg(&argv[2..]).await;
+            return;
+        }
+        _ => {}
+    }
+
+    let args = Args::new_from(argv.into_iter());
 
     // Start pricing fetch in background (will be ready by time generation completes)
     let mut pricing_cache = PricingCache::new();

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,0 +1,237 @@
+//! `prepare-commit-msg` git hook integration.
+//!
+//! Installing the hook lets cmt fill in the commit message inside plain
+//! `git commit` (and IDE / `git gui` / lazygit commit boxes) — not just when the
+//! user types `cmt`. The installed hook calls `cmt prepare-commit-msg "$1" "$2"`;
+//! cmt writes the generated message into the commit-message file and always
+//! exits 0 so it can never block a commit.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use git2::Repository;
+
+const BEGIN_MARKER: &str = "### BEGIN CMT HOOK ###";
+const END_MARKER: &str = "### END CMT HOOK ###";
+const HOOK_NAME: &str = "prepare-commit-msg";
+
+/// Hook error type.
+#[derive(Debug, thiserror::Error)]
+pub enum HookError {
+    #[error("{0}")]
+    Io(#[from] std::io::Error),
+    #[error("could not determine the current executable path: {0}")]
+    Exe(String),
+}
+
+/// Resolve the git hooks directory, honoring `core.hooksPath` (used by Husky
+/// and friends) and falling back to `<gitdir>/hooks`.
+pub fn hooks_dir(repo: &Repository) -> PathBuf {
+    if let Ok(cfg) = repo.config() {
+        if let Ok(custom) = cfg.get_string("core.hooksPath") {
+            if !custom.trim().is_empty() {
+                let p = PathBuf::from(custom);
+                return if p.is_absolute() {
+                    p
+                } else {
+                    // Relative to the working tree, per git semantics.
+                    repo.workdir().unwrap_or_else(|| repo.path()).join(p)
+                };
+            }
+        }
+    }
+    repo.path().join("hooks")
+}
+
+/// Decide whether the hook should generate a message for this commit.
+///
+/// Mirrors the conservative rule used by gptcommit/aicommits: only generate for
+/// a fresh, source-less commit. Skip when the user supplied `-m`/`-F` (message),
+/// a commit template, or a merge/squash/amend message — clobbering those is the
+/// fastest way to get the hook uninstalled.
+pub fn hook_should_generate(commit_source: Option<&str>) -> bool {
+    match commit_source.map(str::trim) {
+        None | Some("") => true,
+        // "message" (-m/-F), "template" (-t), "merge", "squash", "commit" (amend)
+        Some(_) => false,
+    }
+}
+
+/// The hook script body that invokes cmt with the given absolute exe path.
+fn hook_block(exe: &str) -> String {
+    format!(
+        "{BEGIN_MARKER}\n\"{exe}\" prepare-commit-msg \"$1\" \"$2\" \"$3\" || true\n{END_MARKER}\n"
+    )
+}
+
+/// Install (or update) the cmt `prepare-commit-msg` hook. Coexists with any
+/// existing hook content by appending a marker-delimited block. Returns the
+/// hook file path.
+pub fn install(repo: &Repository) -> Result<PathBuf, HookError> {
+    let exe = std::env::current_exe()
+        .map_err(|e| HookError::Exe(e.to_string()))?
+        .to_string_lossy()
+        .into_owned();
+
+    let dir = hooks_dir(repo);
+    fs::create_dir_all(&dir)?;
+    let path = dir.join(HOOK_NAME);
+
+    let existing = fs::read_to_string(&path).unwrap_or_default();
+    let cleaned = strip_block(&existing);
+
+    let new_content = if cleaned.trim().is_empty() {
+        format!("#!/bin/sh\n{}", hook_block(&exe))
+    } else {
+        // Preserve the user's existing hook, append our block.
+        let mut c = cleaned;
+        if !c.ends_with('\n') {
+            c.push('\n');
+        }
+        c.push_str(&hook_block(&exe));
+        c
+    };
+
+    fs::write(&path, new_content)?;
+    make_executable(&path)?;
+    Ok(path)
+}
+
+/// Remove the cmt block from the hook. If nothing else remains (just a shebang),
+/// the hook file is removed entirely. Returns whether a hook was present.
+pub fn uninstall(repo: &Repository) -> Result<bool, HookError> {
+    let path = hooks_dir(repo).join(HOOK_NAME);
+    let Ok(existing) = fs::read_to_string(&path) else {
+        return Ok(false);
+    };
+    if !existing.contains(BEGIN_MARKER) {
+        return Ok(false);
+    }
+
+    let cleaned = strip_block(&existing);
+    let meaningful = cleaned
+        .lines()
+        .any(|l| !l.trim().is_empty() && !l.trim_start().starts_with("#!"));
+
+    if meaningful {
+        fs::write(&path, cleaned)?;
+    } else {
+        fs::remove_file(&path)?;
+    }
+    Ok(true)
+}
+
+/// Remove the marker-delimited cmt block (and any all-comment script) from hook
+/// text, leaving the rest intact.
+fn strip_block(content: &str) -> String {
+    let mut out = String::with_capacity(content.len());
+    let mut in_block = false;
+    for line in content.split_inclusive('\n') {
+        let trimmed = line.trim();
+        if trimmed == BEGIN_MARKER {
+            in_block = true;
+            continue;
+        }
+        if trimmed == END_MARKER {
+            in_block = false;
+            continue;
+        }
+        if !in_block {
+            out.push_str(line);
+        }
+    }
+    out
+}
+
+#[cfg(unix)]
+fn make_executable(path: &Path) -> Result<(), HookError> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(perms.mode() | 0o755);
+    fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn make_executable(_path: &Path) -> Result<(), HookError> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_skip_matrix() {
+        assert!(hook_should_generate(None));
+        assert!(hook_should_generate(Some("")));
+        for src in ["message", "template", "merge", "squash", "commit"] {
+            assert!(!hook_should_generate(Some(src)), "should skip {src}");
+        }
+    }
+
+    #[test]
+    fn test_strip_block_removes_only_cmt_block() {
+        let content = format!(
+            "#!/bin/sh\necho keep-me\n{BEGIN_MARKER}\n\"cmt\" prepare-commit-msg \"$1\" || true\n{END_MARKER}\necho also-keep\n"
+        );
+        let stripped = strip_block(&content);
+        assert!(stripped.contains("echo keep-me"));
+        assert!(stripped.contains("echo also-keep"));
+        assert!(!stripped.contains("prepare-commit-msg"));
+        assert!(!stripped.contains(BEGIN_MARKER));
+    }
+
+    #[test]
+    fn test_hook_block_is_marker_wrapped_and_calls_cmt() {
+        let b = hook_block("/usr/local/bin/cmt");
+        assert!(b.starts_with(BEGIN_MARKER));
+        assert!(b.trim_end().ends_with(END_MARKER));
+        assert!(b.contains("/usr/local/bin/cmt"));
+        assert!(b.contains("prepare-commit-msg"));
+        assert!(b.contains("|| true"), "must never fail the commit");
+    }
+
+    #[test]
+    fn test_install_and_uninstall_roundtrip() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(tmp.path()).unwrap();
+
+        let path = install(&repo).unwrap();
+        assert!(path.exists());
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains(BEGIN_MARKER));
+        assert!(content.contains("prepare-commit-msg"));
+
+        // Idempotent: installing again doesn't duplicate the block.
+        install(&repo).unwrap();
+        let content2 = fs::read_to_string(&path).unwrap();
+        assert_eq!(content2.matches(BEGIN_MARKER).count(), 1);
+
+        // Uninstall removes the now-bare hook file.
+        assert!(uninstall(&repo).unwrap());
+        assert!(!path.exists());
+        // Second uninstall is a no-op.
+        assert!(!uninstall(&repo).unwrap());
+    }
+
+    #[test]
+    fn test_uninstall_preserves_other_hook_content() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let repo = Repository::init(tmp.path()).unwrap();
+        let dir = hooks_dir(&repo);
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(HOOK_NAME);
+        fs::write(&path, "#!/bin/sh\necho pre-existing\n").unwrap();
+
+        install(&repo).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("echo pre-existing"));
+        assert!(content.contains(BEGIN_MARKER));
+
+        uninstall(&repo).unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.contains("echo pre-existing"), "user hook clobbered");
+        assert!(!content.contains(BEGIN_MARKER));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ mod cmtignore;
 mod commit;
 mod config;
 mod git;
+pub mod hook;
 pub mod pricing;
 mod progress;
 mod prompts;


### PR DESCRIPTION
> **The headline feature** — and the largest/most novel change, so I'm leaving it open for your review rather than auto-merging. It's green and dogfood-validated end-to-end.

The #1 gap vs. opencommit/aicommits/gptcommit (per the commit-tool research): cmt could only run as a standalone command. Now it can fill in the message for **plain `git commit`** and IDE / `git gui` / lazygit commit boxes — for people who never type `cmt`.

## Commands
- **`cmt hook install` / `cmt hook uninstall`** — writes a marker-delimited `prepare-commit-msg` hook that invokes the cmt binary (absolute path embedded at install time). Honors `core.hooksPath` (Husky-compatible), else `.git/hooks`; **coexists** with an existing hook (idempotent install; uninstall surgically removes only cmt's block and preserves the rest).
- **`cmt prepare-commit-msg <file> <source> <sha>`** (git-invoked) — generates a message and writes it into the commit-message file.

## Safety (what keeps it from getting uninstalled)
- **Skip matrix**: only fills a *fresh, source-less* commit. `git commit -m`, `-t <template>`, merges, squashes, and amends are left untouched — a user-supplied message is never clobbered.
- **Never blocks a commit**: on missing API key / network / API error it exits 0 and leaves the message alone (the hook line also ends in `|| true`).
- **Secrets redacted** before sending, same as the normal path.

Subcommands are dispatched from argv before clap parsing, so plain `cmt` is unchanged.

## Validation
- `cargo fmt --check` ✅ · `cargo clippy --locked --all-targets -- -D warnings` ✅ (exit 0) · `cargo test` ✅ (5 new `hook` unit tests: skip matrix, block-strip, install/uninstall roundtrip, preserve-other-hook)
- **End-to-end dogfood** in a throwaway repo:
  - `cmt hook install` → plain `git commit` (no `-m`) auto-filled *"test: add entry point for hook test"* with a body ✅
  - `git commit -m "manual message"` → preserved verbatim, not regenerated ✅
  - `cmt hook uninstall` → hook removed cleanly ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)